### PR TITLE
create file location for uploading images/videos/files

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -129,7 +129,6 @@ mkdir -p $datadir/upload/surveys
 rmdir $datadir 2> /dev/null && mv "$final_path/upload" $datadir || true
 chmod -R o-rwx "$datadir"
 chown -R $app:www-data "$datadir"
-chown -h $app:www-data upload
 ln -s $datadir/upload $final_path/upload 2> /dev/null || true
 
 #=================================================

--- a/scripts/install
+++ b/scripts/install
@@ -129,6 +129,7 @@ mkdir -p $datadir/upload/surveys
 rmdir $datadir 2> /dev/null && mv "$final_path/upload" $datadir || true
 chmod -R o-rwx "$datadir"
 chown -R $app:www-data "$datadir"
+chown -h $app:www-data upload
 ln -s $datadir/upload $final_path/upload 2> /dev/null || true
 
 #=================================================

--- a/scripts/install
+++ b/scripts/install
@@ -123,7 +123,7 @@ ynh_script_progression --message="Creating a data directory..." --weight=1
 datadir=/home/yunohost.app/$app
 ynh_app_setting_set --app=$app --key=datadir --value=$datadir
 
-mkdir -p $datadir/upload
+mkdir -p $datadir/upload/surveys
 
 # Remove upload if empty
 rmdir $datadir 2> /dev/null && mv "$final_path/upload" $datadir || true


### PR DESCRIPTION
## Problem

`/home/yunohost.app/limesurvey_app_path/upload/surveys` location is needed for uploading images/files. Otherwise you cannot use images/videos or external files. To reproduce try to add a file in Surveys > Example Survey > Settings > Resources. You will see a blank (white) page. But there must be a embedded file explorer

## Solution

just created path

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
