### PR TITLE
Fix `bookworm` compatibility

### DIFF
--- a/conf/extra_php-fpm.conf
+++ b/conf/extra_php-fpm.conf
@@ -1,0 +1,1 @@
+php_value[short_open_tag]=1

--- a/conf/extra_php-fpm.conf
+++ b/conf/extra_php-fpm.conf
@@ -1,3 +1,1 @@
-php_value[short_open_tag]=1
-php_flag[display_errors] = on
-php_flag[display_startup_errors] = on
+

--- a/conf/extra_php-fpm.conf
+++ b/conf/extra_php-fpm.conf
@@ -1,1 +1,3 @@
 php_value[short_open_tag]=1
+php_flag[display_errors] = on
+php_flag[display_startup_errors] = on

--- a/manifest.toml
+++ b/manifest.toml
@@ -87,14 +87,14 @@ ram.runtime = "50M"
     [resources.apt]
     packages = [
         "python3-pip",
-        "php7.4-cli",
-        "php7.4-fpm",
-        "php7.4-mysql",
-        "php7.4-imap",
-        "php7.4-gd",
-        "php7.4-ldap",
-        "php7.4-zip",
-        "php7.4-mbstring",
+        "php8.2-cli",
+        "php8.2-fpm",
+        "php8.2-mysql",
+        "php8.2-imap",
+        "php8.2-gd",
+        "php8.2-ldap",
+        "php8.2-zip",
+        "php8.2-mbstring",
         "mariadb-server",
     ]
 

--- a/manifest.toml
+++ b/manifest.toml
@@ -95,6 +95,7 @@ ram.runtime = "50M"
         "php8.2-ldap",
         "php8.2-zip",
         "php8.2-mbstring",
+        "php8.2-xml",
         "mariadb-server",
     ]
 


### PR DESCRIPTION
## Problem

- `bookworm` compatibility

## Solution

- Bump php to 8.2
- add missing dependency

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
