### PR TITLE
Fix uploads ownership

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -37,6 +37,7 @@ ln -s "$data_dir/upload" "$install_dir/upload"
 chmod 750 "$install_dir"
 chmod -R o-rwx "$install_dir"
 chown -R "$app:www-data" "$install_dir"
+chown -R "$app:www-data" "$data_dir/upload"
 
 #=================================================
 # ADD A CONFIGURATION


### PR DESCRIPTION
## Problem

- */home/yunohost.app/limesurvey/upload is owned by root on a fresh install*
- https://github.com/YunoHost-Apps/limesurvey_ynh/issues/126

## Solution

- *Give correct ownership*
- After testing manually changing ownership, the app works correctly

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
