### PR TITLE
Keep encryption keys during upgrade

### DIFF
--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -40,7 +40,7 @@ fi
 ynh_script_progression "Upgrading source files..."
 
 # Download, check integrity, uncompress and patch the source from manifest.toml
-ynh_setup_source --dest_dir="$install_dir" --full_replace --keep="plugins/ application/config/config.php"
+ynh_setup_source --dest_dir="$install_dir" --full_replace --keep="plugins/ application/config/config.php application/config/security.php"
 
 ynh_safe_rm "$install_dir/upload"
 ln -s "$data_dir/upload" "$install_dir/upload"


### PR DESCRIPTION
## Problem

After latest update I had a HTTP 500 error (Wrong decryption key) after logging in at `/admin`.
<img width="1282" height="265" alt="image" src="https://github.com/user-attachments/assets/a6a22a1a-c15c-4d7c-829f-7697fb27d911" />

Same as here: https://forums.limesurvey.org/forum/installation-a-update-issues/120567-encryption-keys-after-update 

The encryption keys are saved in `INSTALL_DIR/application/config/security.php`. This is an example `security.php` file:

```php
<?php if (!defined('BASEPATH')) exit('No direct script access allowed');
/*
 * LimeSurvey
 * Copyright (C) 2007-2019 The LimeSurvey Project Team / Carsten Schmitz
 * All rights reserved.
 * License: GNU/GPL License v3 or later, see LICENSE.php
 * LimeSurvey is free software. This version may have been modified pursuant
 * to the GNU General Public License, and as distributed it includes or
 * is derivative of works licensed under the GNU General Public License or
 * other free or open source software licenses.
 * See COPYRIGHT.php for copyright notices and details.
 */

/* 
WARNING!!!
ONCE SET, ENCRYPTION KEYS SHOULD NEVER BE CHANGED, OTHERWISE ALL ENCRYPTED DATA COULD BE LOST !!!

*/

$config = array();
$config['encryptionnonce'] = '<NONCE>';
$config['encryptionsecretboxkey'] = '<KEY>';
return $config;
```

By going through my restic backups I could see that these keys have indeed been changed after each upgrade which is not how it's supposed to be. I could finally find my working encryption keys in an old backup.


## Solution

Instead of regenerating `INSTALL_DIR/application/config/security.php` during each upgrade keep it.

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
